### PR TITLE
Increase percision on RegEx statement that was triggering on wiki conten...

### DIFF
--- a/Strapping.skin.php
+++ b/Strapping.skin.php
@@ -263,7 +263,7 @@ class StrappingTemplate extends BaseTemplate {
 
         <!-- innerbodycontent -->
         <?php # Peek into the body content of articles, to see if a custom layout is used
-        if ($wgStrappingSkinUseStandardLayout || preg_match("/class.*row/i", $this->data['bodycontent']) && $this->data['articleid']) {
+        if ($wgStrappingSkinUseStandardLayout || preg_match("/<div.*class.*row.*>/i", $this->data['bodycontent']) && $this->data['articleid']) {
           # If there's a custom layout, the H1 and layout is up to the page ?>
           <div id="innerbodycontent" class="layout">
             <h1 id="firstHeading" class="firstHeading page-header">


### PR DESCRIPTION
Increase precision on RegEx statement that was changing tags on body content if it contained the string 'class' followed by the string 'row' eg. 'Middle class .... borrowing has increased'.
