### PR TITLE
 Moving skin description to the file documentation section and I18n changes

### DIFF
--- a/Strapping.i18n.php
+++ b/Strapping.i18n.php
@@ -13,5 +13,13 @@ $messages = array();
  */
 $messages['en'] = array(
 	'skinname-strapping' => "Strapping",
-	'strapping-desc' => "Strapping is built on top of a modified Vector theme from MediaWiki and utilizes Twitter's Bootstrap for base layout, typography, and additional widgets.",
+	'strapping-desc' => "Provides a modified Vector skin utilizing Twitter's Bootstrap",
+);
+
+/** German (Deutsch)
+* @author Kghbln
+*/
+$messages['de'] = array(
+        'skinname-strapping' => 'Strapping',
+        'strapping-desc' => 'Stellt eine auf die Benutzeroberfläche „Vector“ sowie Twitters „Bootstrap“ gestützte Benutzeroberfläche bereit'
 );

--- a/strapping.php
+++ b/strapping.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Initialization file fo the Strapping skin
+ * Initialization file for the Strapping skin
  *
  * Strapping is a skin built on top of a modified Vector theme from
  * MediaWiki and utilizes Twitter's Bootstrap for base layout,

--- a/strapping.php
+++ b/strapping.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * My Skin skin
+ * Initialization file fo the Strapping skin
+ *
+ * Strapping is a skin built on top of a modified Vector theme from
+ * MediaWiki and utilizes Twitter's Bootstrap for base layout,
+ * typography, and additional widgets.
  *
  * @file
  * @ingroup Skins


### PR DESCRIPTION
This commit provides the following changes:
- Moves the lengthy skin description to the description section of the initialization file
- Shortens the skin's description shown on Special:Version to correspond with MW habits
- Adds German translation
