### PR TITLE
"Twitter Bootstrap" is now simply Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and was primarily created to provide a great default for wiki-as-a-website
 — but it works well for standard wikis too.
 
 Strapping is built on top of a modified Vector theme from **[MediaWiki](http://mediawiki.org/)**
-and utilizes Twitter's **[Bootstrap](http://twitter.github.com/bootstrap/)**
+and utilizes **[Bootstrap](http://getbootstrap.com/)**
 for base layout, typography, and additional widgets.
 
 Because Strapping uses Bootstrap with its responsive extension,
@@ -100,7 +100,7 @@ Bootstrap has a customization page
 where you can change several aspects of the Bootstrap theme.
 Simply:
 
-1. Visit [the Bootstrap customizer page](http://twitter.github.com/bootstrap/customize.html)
+1. Visit [the Bootstrap customizer page](http://getbootstrap.com/customize/)
 2. change values
 3. click the giant button at the bottom of the page
 4. replace Strapping's `bootstrap` directory with the one in your ZIP file
@@ -179,7 +179,7 @@ It looks something like this:
 ```
 
 For more information,
-please visit [Bootstrap's documentation](http://twitter.github.com/bootstrap/scaffolding.html).
+please visit [Bootstrap's documentation](http://getbootstrap.com/css/#grid).
 
 
 ### Documentation

--- a/Strapping.i18n.php
+++ b/Strapping.i18n.php
@@ -13,7 +13,7 @@ $messages = array();
  */
 $messages['en'] = array(
 	'skinname-strapping' => "Strapping",
-	'strapping-desc' => "Provides a modified Vector skin utilizing Twitter's Bootstrap",
+	'strapping-desc' => "Provides a modified Vector skin utilizing Bootstrap",
 );
 
 /** German (Deutsch)
@@ -21,5 +21,5 @@ $messages['en'] = array(
 */
 $messages['de'] = array(
         'skinname-strapping' => 'Strapping',
-        'strapping-desc' => 'Stellt eine auf die Benutzeroberfläche „Vector“ sowie Twitters „Bootstrap“ gestützte Benutzeroberfläche bereit'
+        'strapping-desc' => 'Stellt eine auf die Benutzeroberfläche „Vector“ sowie „Bootstrap“ gestützte Benutzeroberfläche bereit'
 );

--- a/strapping.php
+++ b/strapping.php
@@ -3,7 +3,7 @@
  * Initialization file for the Strapping skin
  *
  * Strapping is a skin built on top of a modified Vector theme from
- * MediaWiki and utilizes Twitter's Bootstrap for base layout,
+ * MediaWiki and utilizes Bootstrap for base layout,
  * typography, and additional widgets.
  *
  * @file


### PR DESCRIPTION
See http://getbootstrap.com/about/#brand
Also updates links to Bootstrap's website.
