### PR TITLE
Fixed using of deprecated API. Now strapping is compatible with mediawiki 1.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can see a (customized) instance of Strapping in action by visiting http://ol
 2. Clone the repository:
 
    ```
-   git clone https://github.com/axxie/strapping-mediawiki strapping
+   git clone https://github.com/OSAS/strapping-mediawiki strapping
    ```
 
 3. Add the following to `LocalSettings.php`: 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and have an easy-to-work with site
 so that anyone could either stick to MediaWiki marked up pages
 or do some more advanced layout (with columns, etc.) using Bootstrap.
 
-You can see a (customized) instance of Strapping in action by visiting http://oVirt.org/
+You can see a (customized) instance of Strapping in action by visiting http://old.ovirt.org/Home
 
 
 ## Requirements
@@ -49,7 +49,7 @@ You can see a (customized) instance of Strapping in action by visiting http://oV
 2. Clone the repository:
 
    ```
-   git clone https://github.com/OSAS/strapping-mediawiki strapping
+   git clone https://github.com/axxie/strapping-mediawiki strapping
    ```
 
 3. Add the following to `LocalSettings.php`: 

--- a/Strapping.skin.php
+++ b/Strapping.skin.php
@@ -104,7 +104,7 @@ class StrappingTemplate extends BaseTemplate {
     $nav = $this->data['content_navigation'];
 
     if ( $wgVectorUseIconWatch ) {
-      $mode = $this->getSkin()->getTitle()->userIsWatching() ? 'unwatch' : 'watch';
+      $mode = $this->getSkin()->getUser()->isWatched($this->getSkin()->getTitle()) ? 'unwatch' : 'watch';
       if ( isset( $nav['actions'][$mode] ) ) {
         $nav['views'][$mode] = $nav['actions'][$mode];
         $nav['views'][$mode]['class'] = rtrim( 'icon ' . $nav['views'][$mode]['class'], ' ' );


### PR DESCRIPTION
Mediawiki developers declared userIsWatching() as deprecated in 1.20 and completely removed in 1.27.
The proposed change fixes using of the removed API.
